### PR TITLE
Fixes #188

### DIFF
--- a/frontend/components/resources/resourcesLinks.tsx
+++ b/frontend/components/resources/resourcesLinks.tsx
@@ -14,7 +14,7 @@ const ResourceTenantLinks = () => {
 				return (
 					<div
 						key={country}
-						className="mx-auto flex max-w-7xl flex-row flex-wrap justify-center gap-4 px-6 text-lg lg:px-8"
+						className="my-4 mx-auto flex max-w-7xl flex-row flex-wrap justify-center gap-4 px-6 text-lg lg:px-8"
 					>
 						<h3 className="mt-2 block w-full text-center text-3xl font-bold leading-8 tracking-tight text-gray-900 sm:text-4xl">
 							{country}
@@ -25,9 +25,9 @@ const ResourceTenantLinks = () => {
 									data-umami-event={`Resource - ${link.name}`}
 									href={link.link}
 									key={link.name}
-									className="w-full cursor-pointer rounded-lg bg-white px-4 py-5 text-center text-black shadow hover:bg-teal-600 hover:text-white sm:p-6 lg:w-auto lg:text-left"
+									className="w-full cursor-pointer rounded-lg bg-white px-4 py-5 text-center text-black shadow shadow-slate-400 hover:bg-teal-600 hover:text-white sm:p-6 lg:w-auto lg:text-left"
 								>
-									<p className="mt-1 text-3xl font-semibold tracking-tight">
+									<p className="mt-1 text-xl font-semibold tracking-tight">
 										{link.name}
 									</p>
 									{link.country === link.city ? (


### PR DESCRIPTION
Use visual hierarchy in font sizes to illustrate the difference between heading, button main content and sub-content. 

Add box-shadow in button to make them appear more like a button.

Output
![Screen Shot 2023-05-04 at 12 37 33](https://user-images.githubusercontent.com/1433681/236134247-a3ad33e8-3e23-4096-aa41-4874a3270c87.png)
