### PR TITLE
Export env vars from env file in CI process

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -91,6 +91,7 @@ jobs:
           echo PGPORT=${{secrets.PGPORT}} >> .env
           echo PGUSERNAME=${{secrets.PGUSERNAME}} >> .env
           cat .env
+          source .env
       - name: Pull Docker
         run: docker-compose pull
       - name: Build Docker


### PR DESCRIPTION
Fixes #246 

Export env vars declared in .env file in CI process.

I verified the fix by [running the workflow](https://github.com/ritesh-pandey/RateTheLandlord/actions/runs/4885087643/jobs/8718722585) on my forked version. 